### PR TITLE
Replace splitHttpMessages with packageAndSendToCloudProxy which consi…

### DIFF
--- a/cloudwebapp/src/main/java/com/proxy/cloudListener/CloudInstanceMap.java
+++ b/cloudwebapp/src/main/java/com/proxy/cloudListener/CloudInstanceMap.java
@@ -40,7 +40,6 @@ public class CloudInstanceMap {
     Cloud put(String key, Cloud cloud) {
         brokerMessagingTemplate.convertAndSend("/topic/accountUpdates", update);
         createNVRSessionTimer(cloud.getProductId());
-
         return map.put(key, cloud);
     }
 
@@ -51,20 +50,20 @@ public class CloudInstanceMap {
      * @return: The Cloud instance
      */
     public Cloud get(String key) {
-        if (timers.containsKey(key)) {
-            timers.get(key).cancel();
-        }
         return map.get(key);
     }
 
      /**
-     * remove: Remove this key reference to the Cloud instance. If the key is a product ID, remove the Cloud instance and all references
+     * remove: Remove this key reference to the Cloud instance.
      *
      * @param key: The key
      * @return: The Cloud instance
      */
     public Cloud remove(String key) {
         brokerMessagingTemplate.convertAndSend("/topic/accountUpdates", update);
+        Timer timer = timers.remove(key);
+        if(timer != null)
+            timer.cancel();
         return map.remove(key);
     }
 
@@ -75,7 +74,10 @@ public class CloudInstanceMap {
      * @param productId: The Cloud instance
      */
     public void resetNVRTimeout(String productId) {
-        timers.get(productId).cancel();
+        Timer timer = timers.get(productId);
+        if(timer != null)
+            timer.cancel();
+
         createNVRSessionTimer(productId);
     }
 

--- a/cloudwebapp/src/main/java/com/proxy/cloudListener/CloudListener.java
+++ b/cloudwebapp/src/main/java/com/proxy/cloudListener/CloudListener.java
@@ -144,6 +144,7 @@ public class CloudListener implements SslContextProvider {
             newInstance.start();
             instances.put(prodId, newInstance);
         } else {
+            instances.resetNVRTimeout(prodId);
             Cloud cloud = instances.get(prodId);
             cloud.setCloudProxyConnection(cloudProxy);
         }


### PR DESCRIPTION
Replace splitHttpMessages with packageAndSendToCloudProxy which consists of the only functionality actually used in splitHttpMessages (due to protocolAgnostic flag being set).

Register user account no longer does the (unecessary) call to authenticate on the NVR. It just checks there is a Cloud instance for the required productId.